### PR TITLE
Fix Part3MultithreadingParallelizationTest#publishOnParallelThreadSchedulerTest

### DIFF
--- a/work/chapter-1/src/test/java/com/example/part_3/Part3MultithreadingParallelizationTest.java
+++ b/work/chapter-1/src/test/java/com/example/part_3/Part3MultithreadingParallelizationTest.java
@@ -7,6 +7,7 @@ import reactor.test.StepVerifier;
 
 import java.time.Duration;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.example.part_3.Part3MultithreadingParallelization.*;
 


### PR DESCRIPTION
This test was testing nothing (was comparing that currentThread != null). Switched to actually verifying that publishOn was used.